### PR TITLE
docs: add README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,57 @@
-@AGENTS.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Stack & version caveats
+
+- **Next.js 16.2** with the App Router, **React 19**, **Tailwind CSS v4**, **framer-motion 12**, **next-themes**, **TypeScript 5**. All of these have breaking changes vs. typical training data — when in doubt, read the relevant guide in `node_modules/next/dist/docs/` before changing routing, metadata, image, or font APIs.
+- Tailwind v4 is configured purely via `app/globals.css` (`@import "tailwindcss";`, `@custom-variant dark (&:is(.dark *))`, `@theme inline { ... }`). There is no `tailwind.config.ts`. Add new design tokens / keyframes / variants inside `globals.css`.
+- Package manager is **pnpm** (`pnpm-lock.yaml`, `pnpm-workspace.yaml`). Use `pnpm` for installs.
+
+## Commands
+
+```bash
+pnpm dev            # next dev (Turbopack)
+pnpm build          # next build
+pnpm start          # next start
+pnpm lint           # eslint (flat config in eslint.config.mjs)
+```
+
+No test runner is configured.
+
+## Persistent-shell architecture (important)
+
+The app deliberately separates **always-mounted chrome** from **per-route content** so the navbar, animated background, and starfield never remount when navigating:
+
+- `app/layout.tsx` — sets up fonts, `ThemeProvider` (next-themes, `class` strategy, `dark` default), and wraps everything in `<ClientShell>`.
+- `components/ClientShell.tsx` — renders the gradient background, drift orbs, `StarBackground`, `ShootingStars`, the global `Navbar`, and the footer. Everything inside lives in `<main>{children}</main>` so it stays mounted across nav.
+- `app/template.tsx` — fades/slides the route subtree (`opacity` + `y`) on every navigation. **Anything that should re-animate on each nav goes inside the template's subtree; anything that should persist (navbar pill, background) goes in `ClientShell`.**
+- `components/Navbar.tsx` — uses framer-motion `layoutId` (`desktop-active-pill`, `mobile-active-pill`) so the active-route pill slides between nav items rather than remounting. The mobile navbar is `fixed bottom-5`; the desktop one is `fixed top-5`.
+
+Adding a new route: create `app/<route>/page.tsx` that returns a single Section component from `components/sections/`. Add the entry to `Navbar.tsx`'s `navItems` array so the pill animation includes it.
+
+## Data layer
+
+Everything user-facing comes from `lib/data.ts`:
+
+- `profileTitles`, `profileInfo` (with `taglineParts.{lead,highlight,trail}` for the hero), `experiences`, `education`, `skillCategories`.
+- `Experience.period` and `Education.period` follow the format `"Mon YYYY – Mon YYYY"` or `"Mon YYYY – Present"`. `ExperienceSection.tsx` has a `periodStartKey` parser that turns this into `YYYYMM` for chronological sort; if you change the format, update that parser and `periodToDateTime`.
+- `SkillCategory.accent` must match a key in `accentStyles` in `SkillsSection.tsx` (`blue`, `violet`, `emerald`, `amber`, `rose`, `cyan`, `slate`, `indigo`). Adding a new accent requires both a `lib/data.ts` entry and a new entry in `accentStyles`.
+- `SkillCategory.icon` must match a key in `iconMap` in `SkillsSection.tsx`.
+
+## Section conventions
+
+- All section components live in `components/sections/` and are client components.
+- Reusable building blocks are in `components/ui/` (`GlassCard`, `TracingBeam`, `ThemeToggle`, `StarBackground`, `ShootingStars`, `hero-highlight`).
+- `cn()` from `lib/utils.ts` (clsx + tailwind-merge) is the only className helper — use it for conditional classes.
+- Entrance animation pattern is framer-motion variants with `initial="hidden" whileInView="visible" viewport={{ once: true }}`. The `stagger` / `fadeUp` / `fadeLeft` variant trio in `HomeSection.tsx` is the canonical example.
+- Decorative icons should get `aria-hidden="true"`. Date pills use `<time dateTime="YYYY-MM">` semantics.
+
+## Two pieces of subtle code worth knowing
+
+- **`components/ui/TracingBeam.tsx`** — measures `contentRef` via a `ResizeObserver` (not a one-shot `offsetHeight`) and drives the dot's `boxShadow`/`backgroundColor`/`borderColor` through `useTransform` + `useMotionTemplate` so they react live to scroll. Do **not** read `scrollYProgress.get()` inside an `animate={{...}}` prop — that captures a snapshot at render time and the dot will freeze on the initial state.
+- **`components/sections/ExperienceSection.tsx`** — builds a single `timeline` array that interleaves `experiences` and `education` items sorted by start date descending, then renders each via a discriminated `kind: 'experience' | 'education'` branch inside the shared `TracingBeam`. Education cards are visually distinguished by an amber tint and omit description/tech rows.
+
+## Responsive home page
+
+`HomeSection.tsx` locks to **exactly the viewport height on mobile** (`h-[100dvh]` + `overflow-hidden`) and lets the inner `GlassCard` scroll (`overflow-y-auto`) so the floating bottom navbar always stays in its gap. On `md+` it reverts to natural-height + `min-h-screen`. The right-column info cards (Focus / Stack / Open-to) are `hidden md:flex` — a compact `<CurrentlyCard compact />` is rendered inline under the tagline on mobile instead. Changes to the hero spacing usually need to be checked at three breakpoints: mobile (locked viewport), `sm` (still single-column), and `md+` (two-column grid).

--- a/README.md
+++ b/README.md
@@ -1,36 +1,118 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Julius Dsouza — Portfolio
 
-## Getting Started
+Personal portfolio site for Julius Dsouza — Software Engineer at Meta.
+Built as a small, polished, fully responsive single-author site with light/dark themes, scroll-driven animations, and a data-driven content layer.
 
-First, run the development server:
+Live sections:
+
+- **Home** (`/`) — hero card with title pills, animated tagline highlight, animated stat counters, CTAs, and an "About me" info panel.
+- **Experience** (`/experience`) — a unified, chronologically-sorted timeline that interleaves work experience and education into a single TracingBeam-animated column.
+- **Skills** (`/skills`) — a bento-grid of skill categories with per-category accent theming and pop-in pill animations.
+
+## Tech stack
+
+| Area | Choice |
+|---|---|
+| Framework | **Next.js 16.2** (App Router, Turbopack) |
+| Language | TypeScript 5 |
+| UI runtime | React 19 |
+| Styling | **Tailwind CSS v4** (configured entirely in `app/globals.css`) |
+| Animation | framer-motion 12 |
+| Theming | next-themes (`class` strategy, dark default) |
+| Icons | lucide-react |
+| Utilities | clsx + tailwind-merge (wrapped as `cn()`) |
+| Package manager | pnpm |
+
+## Getting started
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install
+pnpm dev          # → http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Other scripts:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+pnpm build        # production build
+pnpm start        # serve the production build
+pnpm lint         # eslint (flat config)
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Architecture
 
-## Learn More
+The site is intentionally small but uses a few non-obvious patterns worth knowing:
 
-To learn more about Next.js, take a look at the following resources:
+### Persistent shell + per-route content
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+`app/layout.tsx` mounts `<ClientShell>` once. The shell renders the gradient background, animated drift orbs (light mode), `StarBackground` + `ShootingStars` (dark mode), the floating `Navbar`, and the footer. It then renders `{children}` inside `<main>`, which means the chrome **never remounts on navigation** — the navbar's active-route pill slides between sections via framer-motion `layoutId` shared layout animation rather than fading in and out.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+`app/template.tsx` wraps the route subtree in a `motion.div` that fades + slides up on every navigation, so route content gets a fresh entrance animation without disturbing the shell.
 
-## Deploy on Vercel
+### Data-driven content
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Everything user-facing lives in `lib/data.ts`:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `profileTitles` — the colored pill labels on the hero (e.g. "Software Engineer", "Fullstack Engineer", "AI Engineer").
+- `profileInfo` — name, bio, current role, focus card, stack card, "open to" callout, social links, and a three-part `taglineParts` (lead / highlight / trail) for the animated tagline highlight.
+- `experiences`, `education` — both are surfaced on `/experience` as one chronologically-sorted timeline.
+- `skillCategories` — each entry carries a `category`, `skills[]`, an `icon` key (matches a map in `SkillsSection`), and an `accent` key (matches the per-color token map in `SkillsSection`).
+
+To edit content, change `lib/data.ts`. No JSX needs to be touched for the usual case.
+
+### Theming
+
+Tailwind v4 is configured purely via `app/globals.css`:
+
+- `@import "tailwindcss";`
+- `@custom-variant dark (&:is(.dark *));`
+- Custom keyframes (`drift`, `twinkle`, `shooting`, `float`) and design tokens declared in `@theme inline { ... }`.
+
+There is no `tailwind.config.ts`. Add new tokens, keyframes, or variants in `globals.css`.
+
+`next-themes` toggles a `.dark` class on `<html>` with `defaultTheme="dark"` and `enableSystem`.
+
+### Responsive home page
+
+`HomeSection` locks to exactly `100dvh` on mobile and lets the inner `GlassCard` scroll, so the floating bottom navbar always sits in its own reserved gap. The right-column info cards (Currently / Focus / Stack / Open-to) are hidden below `md`; a compact `<CurrentlyCard compact />` is rendered inline under the tagline on mobile instead. From `md+` upward the layout switches to a two-column grid with natural height.
+
+## Project layout
+
+```
+app/
+  layout.tsx          # Root layout — fonts, ThemeProvider, ClientShell
+  template.tsx        # Per-navigation fade/slide of the route subtree
+  page.tsx            # /         → HomeSection
+  experience/page.tsx # /experience → ExperienceSection (work + education timeline)
+  skills/page.tsx     # /skills    → SkillsSection
+  globals.css         # Tailwind v4 import, dark variant, keyframes, tokens
+
+components/
+  ClientShell.tsx     # Persistent chrome (background, navbar, footer)
+  Navbar.tsx          # Desktop top pill + mobile bottom pill with layoutId animation
+  sections/           # One file per route — HomeSection / ExperienceSection / SkillsSection
+  ui/                 # Reusable building blocks — GlassCard, TracingBeam,
+                      # ThemeToggle, StarBackground, ShootingStars, hero-highlight
+
+lib/
+  data.ts             # Single source of truth for all rendered content
+  utils.ts            # cn() — clsx + tailwind-merge
+
+public/
+  me.png              # Hero avatar
+  resume.pdf          # "View Resume" target
+```
+
+## Customizing for your own use
+
+1. Replace `public/me.png` and `public/resume.pdf`.
+2. Edit `lib/data.ts` — change `profileInfo`, `profileTitles`, `experiences`, `education`, `skillCategories`.
+3. Update the site metadata in `app/layout.tsx` (`metadata.title`, `metadata.description`).
+4. Update the footer credit in `components/ClientShell.tsx`.
+
+To add a new skill accent color, add an entry to `accentStyles` in `components/sections/SkillsSection.tsx` matching the existing shape, then reference it as `accent: '<key>'` on the relevant `skillCategories` entry.
+
+To add a new route, drop a `app/<route>/page.tsx` that renders a section component, then add a corresponding entry to `navItems` in `components/Navbar.tsx` so the active-pill animation includes it.
+
+## Deployment
+
+The site is a standard Next.js 16 build and deploys cleanly on Vercel with no additional configuration. `pnpm build && pnpm start` works for any Node host.


### PR DESCRIPTION
Replaces the Create Next App boilerplate README with a real project README covering live sections, tech stack, getting-started commands, the persistent-shell / data-driven / Tailwind-v4 architecture notes, the mobile 100dvh-locked home layout, a project tree, customization checklist, and deployment.

Adds CLAUDE.md so future Claude Code sessions get oriented quickly to the non-default versions (Next 16 / React 19 / Tailwind v4), the persistent-shell pattern, the lib/data.ts single source of truth (including the period-format parser coupling), the accent/icon map contracts on the Skills page, and the two pieces of subtle code worth knowing — TracingBeam's reactive style props plus its ResizeObserver, and the merged work + education timeline.