### PR TITLE
fix(deploy): enable static export and fix framer-motion Variants typing

### DIFF
--- a/components/sections/HomeSection.tsx
+++ b/components/sections/HomeSection.tsx
@@ -4,7 +4,7 @@ import { GlassCard } from '@/components/ui/GlassCard';
 import { profileTitles, profileInfo } from '@/lib/data';
 import { Highlight } from '@/components/ui/hero-highlight';
 import { FileText, Sparkles, Code, MessageCircle, ArrowRight } from 'lucide-react';
-import { motion, useMotionValue, useTransform, animate, useReducedMotion } from 'framer-motion';
+import { motion, useMotionValue, useTransform, animate, useReducedMotion, type Variants } from 'framer-motion';
 import { useEffect, useRef } from 'react';
 import Image from 'next/image';
 
@@ -95,17 +95,17 @@ function AnimatedNumber({ value }: { value: number }) {
   return <span ref={ref} aria-hidden="true">0</span>;
 }
 
-const stagger = {
+const stagger: Variants = {
   hidden: {},
   visible: { transition: { staggerChildren: 0.1 } },
 };
 
-const fadeUp = {
+const fadeUp: Variants = {
   hidden: { opacity: 0, y: 20 },
   visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: 'easeOut' } },
 };
 
-const fadeLeft = {
+const fadeLeft: Variants = {
   hidden: { opacity: 0, x: 30 },
   visible: { opacity: 1, x: 0, transition: { duration: 0.5, ease: 'easeOut' } },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Emit a fully static site into ./out so it can be hosted by GitHub Pages.
+  output: "export",
+  // next/image's default loader requires a Node server. Disabling optimization
+  // makes <Image> render plain <img> tags that work on static hosts.
+  images: { unoptimized: true },
+  // Strip any trailing slash from request URLs so GitHub Pages' static routing
+  // matches Next's generated files cleanly.
+  trailingSlash: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
`pnpm run deploy` was failing in two places:

1. `pnpm build` (run by `predeploy`) errored on framer-motion 12's stricter typing — `ease: 'easeOut'` in the variant literals was inferred as `string`, but `Variant.transition.ease` requires the `Easing` union. Annotated `stagger`, `fadeUp`, and `fadeLeft` as `Variants` so TS narrows the string literal to the expected token.

2. `gh-pages -d out` had no `out/` directory to deploy because the default Next config emits to `.next/`. Added `output: "export"` to next.config.ts so `next build` writes a fully static `out/` site, plus `images: { unoptimized: true }` (next/image's default loader needs a Node server) and `trailingSlash: true` so GitHub Pages' static routing matches the generated files cleanly.

After this change `pnpm build` produces an `out/` ready for any static host. The deploy targets the default `gh-pages` branch — set GitHub Pages source to that branch in repo settings.