### PR TITLE
fix(deploy): include dotfiles when uploading to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "predeploy": "pnpm run build",
-    "deploy": "gh-pages -d out"
+    "deploy": "gh-pages -d out --dotfiles"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
PR #7 added public/.nojekyll so out/.nojekyll lands in the static export, but the live site was still 404'ing every /_next/* asset after the next deploy. Root cause: the `gh-pages` CLI **excludes dotfiles by default**, so out/.nojekyll was silently skipped during upload — Jekyll stayed enabled on the deployed branch and continued to drop every path beginning with an underscore.

Adding `--dotfiles` (`-t`) to the deploy script tells gh-pages to copy dotfiles too, so .nojekyll ships and Pages stops Jekyll-processing the site. After this lands, run `pnpm run deploy` once and CSS/JS chunks at /_next/static/... will return 200 instead of 404.