### PR TITLE
fix(navbar): match active route when paths carry a trailing slash

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,7 +14,13 @@ const navLinks = [
 ];
 
 export function Navbar() {
-  const pathname = usePathname();
+  const rawPathname = usePathname();
+  // With `trailingSlash: true` (static export), prod paths arrive as
+  // "/experience/" — strip the slash so they match the nav hrefs.
+  const pathname =
+    rawPathname !== '/' && rawPathname?.endsWith('/')
+      ? rawPathname.slice(0, -1)
+      : rawPathname;
 
   return (
     <>


### PR DESCRIPTION
Enabling `trailingSlash: true` for the static export (PR #6) changed production URLs to /experience/ and /skills/. The navbar highlights the active link with a strict `pathname === href` check against hrefs without trailing slashes, so in production no nav item ever matched outside of Home — the sliding active pill vanished and every link rendered in the inactive gray state, and the mobile navbar lost its active label.

Normalize the pathname from usePathname() by stripping a trailing slash (keeping "/" intact) before comparing. Dev behavior is unchanged since dev paths have no trailing slash.